### PR TITLE
elisp/devel: Add guix-devel-code-block-edit

### DIFF
--- a/doc/emacs-guix.texi
+++ b/doc/emacs-guix.texi
@@ -9,7 +9,8 @@ This document describes Emacs-Guix, the Emacs interface for the
 @uref{https://www.gnu.org/software/guix/, GNU Guix} package manager.
 
 @quotation
-Copyright @copyright{} 2014-2018 Alex Kost
+Copyright @copyright{} 2014-2018 Alex Kost@*
+Copyright @copyright{} 2018 Oleg Pykhalov
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3
@@ -180,6 +181,12 @@ or later.  It is used to define various ``list''/``info'' interfaces
 already have this library if you use Magit 2.1.0 or later.  This
 library is required only for @kbd{M-x@tie{}guix} command (@pxref{Popup
 Interface}).
+
+@item
+@uref{https://github.com/Fanael/edit-indirect, emacs-edit-indirect},
+version 0.1.4 or later.  It is used to edit synopsis/description in
+@code{guix-devel-mode} with @kbd{C-c '} key binding which invokes
+@code{guix-devel-code-block-edit} command.
 
 @end itemize
 
@@ -916,6 +923,11 @@ guix, The GNU Guix Reference Manual})
 Lint (check) a package defined by the current variable definition
 (@pxref{Invoking guix lint,,, guix, The GNU Guix Reference Manual})
 (@code{guix-devel-lint-package}).
+
+@item C-c '
+Edit a string following @code{description} or @code{synopsis} package
+field in an indirect buffer.
+(@code{guix-devel-code-block-edit})
 
 @end table
 

--- a/elisp/guix.el
+++ b/elisp/guix.el
@@ -6,7 +6,7 @@
 ;; Version: 0.3.4
 ;; URL: https://alezost.github.io/guix.el/
 ;; Keywords: tools
-;; Package-Requires: ((emacs "24.3") (dash "2.11.0") (geiser "0.8") (bui "1.1.0") (magit-popup "2.1.0"))
+;; Package-Requires: ((emacs "24.3") (dash "2.11.0") (geiser "0.8") (bui "1.1.0") (magit-popup "2.1.0") (edit-indirect "0.1.4"))
 
 ;; This file is part of Emacs-Guix.
 


### PR DESCRIPTION
Hello Alex,

This patch provides functionality similar to Org edit source code block at point.
See https://orgmode.org/manual/Editing-source-code.html

It makes little bit easier to edit `description` and `synopsis` Guix package fields.

* elisp/guix-devel.el: (guix-devel-code-block-syntax): New constant.
(guix-devel-code-block-position, guix-devel-code-block-edit): New
functions.
(guix-devel-mode-map): Add 'guix-devel-code-block-edit'.
* doc/emacs-guix.texi (Development): Document this.