### PR TITLE
Remove `geiser-company--setup`

### DIFF
--- a/elisp/guix-repl.el
+++ b/elisp/guix-repl.el
@@ -328,7 +328,6 @@ this address (it should be defined by
                geiser-guile--debugger-prompt-regexp))
         (geiser-repl--startup impl address)
         (geiser-repl--autodoc-mode 1)
-        (geiser-company--setup geiser-repl-company-p)
         (add-hook 'comint-output-filter-functions
                   'guix-repl-output-filter
                   nil t)


### PR DESCRIPTION
Hi! Thanks for your great maintenance!

`geiser-company--setup` is no longer available, and `geiser-repl--start-repl`, which is one of origin of `guix -start-repl`, does not have `geiser-company--setup` now.

https://gitlab.com/emacs-geiser/geiser/-/blob/master/elisp/geiser-repl.el#L558
https://github.com/alezost/guix.el/blob/c9aef52121b458297e70bb50f49f7276b4a8d759/elisp/guix-repl.el#L331

So I remove it.

Thanks!